### PR TITLE
Add a sample to the payload

### DIFF
--- a/karton/android/android.py
+++ b/karton/android/android.py
@@ -43,6 +43,6 @@ class Android(Karton):
                     "type": "sample",
                     "stage": "analyzed",
                 },
-                payload={"attributes": metadata},
+                payload={"sample": sample, "attributes": metadata},
             )
         )

--- a/tests/test_android.py
+++ b/tests/test_android.py
@@ -22,6 +22,7 @@ class AndroidMagicTestCase(KartonTestCase):
                     "origin": "karton.android",
                 },
                 payload={
+                    "sample": sample,
                     'attributes': {
                       "certificate": ["61ED377E85D386A8DFEE6B864BD85B0BFAA5AF81"],
                       "main_activity": ["com.example.android.contactmanager..ContactManager"],


### PR DESCRIPTION
To properly handle task, karton-mwdb-reprter (and in fact, probably every reporter out there) needs to know **which sample** is being reported. Without this connection, mwdb won't know which sample it should add attributes to.

With this simple change I've confirmed the karton works as expected.

![image](https://user-images.githubusercontent.com/7026881/189234723-0ecb58db-aaf9-4dca-babf-e6315e31b6a8.png)
